### PR TITLE
BUG: Fix Windows install paths

### DIFF
--- a/recipe/cudss-targets-release.cmake
+++ b/recipe/cudss-targets-release.cmake
@@ -1,0 +1,19 @@
+#----------------------------------------------------------------
+# Generated CMake target import file for configuration "Release".
+#----------------------------------------------------------------
+
+# Commands may need to know the format version.
+set(CMAKE_IMPORT_FILE_VERSION 1)
+
+# Import target "cudss" for configuration "Release"
+set_property(TARGET cudss APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+set_target_properties(cudss PROPERTIES
+  IMPORTED_IMPLIB_RELEASE "${cudss_LIBRARY_DIR}/cudss.lib"
+  IMPORTED_LOCATION_RELEASE "${cudss_BINARY_DIR}/cudss64_0.dll"
+  )
+
+list(APPEND _cmake_import_check_targets cudss )
+list(APPEND _cmake_import_check_files_for_cudss "${cudss_LIBRARY_DIR}/cudss.lib" "${cudss_BINARY_DIR}/cudss64_0.dll" )
+
+# Commands beyond this point should not need to know the version.
+set(CMAKE_IMPORT_FILE_VERSION)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,20 +17,23 @@ package:
   version: {{ version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cudss/redist/libcudss/{{ platform }}/libcudss-{{ platform }}-{{ version }}_cuda{{ cuda_major }}-archive.{{ extension }}
-  sha256: b52dfec1ee10bf49c706dd36d4808e7fa02f3c8a85f1c2bb7e0da48dcae51cb0  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
-  sha256: 64d77f5a3d2fafc99704da0c0e686d920265708358b9ced5755da713f3ff0620  # [linux64 and (cuda_compiler_version or "").startswith("12")]
-  sha256: d0801e78eab1be1240198e292bc496bb1804f2068975aaaf80ba31c3e400c625  # [win64   and (cuda_compiler_version or "").startswith("12")]
+  - url: https://developer.download.nvidia.com/compute/cudss/redist/libcudss/{{ platform }}/libcudss-{{ platform }}-{{ version }}_cuda{{ cuda_major }}-archive.{{ extension }}
+    sha256: b52dfec1ee10bf49c706dd36d4808e7fa02f3c8a85f1c2bb7e0da48dcae51cb0  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
+    sha256: 64d77f5a3d2fafc99704da0c0e686d920265708358b9ced5755da713f3ff0620  # [linux64 and (cuda_compiler_version or "").startswith("12")]
+    sha256: d0801e78eab1be1240198e292bc496bb1804f2068975aaaf80ba31c3e400c625  # [win64   and (cuda_compiler_version or "").startswith("12")]
+  # Overwrite cudss-targets-release.cmake to correct broken paths
+  - path: cudss-targets-release.cmake  # [win]
 
 build:
   number: 0
   skip: true  # [(cuda_compiler_version in (None, "None", "11.8")) or (not (linux64 or aarch64 or win64))]
   script:  # [win]
     - md -p %LIBRARY_PREFIX%\examples\cudss  # [win]
-    - cp -rv examples %LIBRARY_PREFIX%\examples\cudss  # [win]
-    - cp -rv include %LIBRARY_INC%  # [win]
-    - cp -rv lib %LIBRARY_LIB%  # [win]
-    - cp -rv bin %LIBRARY_BIN%  # [win]
+    - xcopy examples %LIBRARY_PREFIX%\examples\cudss /E /I /Y /V # [win]
+    - xcopy include %LIBRARY_INC% /E /I /Y /V # [win]
+    - xcopy lib %LIBRARY_LIB% /E /I /Y /V # [win]
+    - xcopy bin %LIBRARY_BIN% /E /I /Y /V # [win]
+    - xcopy cudss-targets-release.cmake %LIBRARY_LIB%\cmake\cudss\ /I /Y /V # [win]
 
 requirements:
   build:
@@ -52,7 +55,7 @@ outputs:
         - {{ pin_subpackage("libcudss" ~ somajor, max_pin="x.x.x") }}
     files:
       - lib/libcudss.so.*  # [linux]
-      - bin/cudss64_0.dll  # [win64]
+      - Library/bin/cudss64_0.dll  # [win]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -82,10 +85,12 @@ outputs:
         - {{ pin_subpackage("libcudss" ~ somajor, max_pin="x.x.x") }}
     files:
       - lib/libcudss.so  # [linux]
-      - lib/cudss.lib  # [win]
-      - include/cudss*
-      - lib/cmake/cudss/cudss-config*
-      - lib/cmake/cudss/cudss-targets*
+      - include/cudss*  # [linux]
+      - lib/cmake/cudss/cudss-config*  # [linux]
+      - lib/cmake/cudss/cudss-targets*  # [linux]
+      - Library/lib/cudss.lib  # [win]
+      - Library/include/cudss*  # [win]
+      - Library/lib/cmake/cudss/*  # [win]
     requirements:
       host:
         - {{ pin_subpackage("libcudss" ~ somajor, exact=True) }}
@@ -106,8 +111,6 @@ outputs:
         - cmake  # [build_platform == target_platform]
         - ninja  # [build_platform == target_platform]
       commands:
-        - cmake ${CMAKE_ARGS} -GNinja test  # [build_platform == target_platform]
-        - cmake --build .  # [build_platform == target_platform]
         - test -f $PREFIX/include/cudss.h  # [linux]
         - test -f $PREFIX/include/cudss_distributed_interface.h  # [linux]
         - test -L $PREFIX/lib/libcudss.so  # [linux]
@@ -116,12 +119,16 @@ outputs:
         - if not exist %LIBRARY_LIB%\\cudss.lib exit 1  # [win]
         - if not exist %LIBRARY_INC%\\cudss.h exit 1  # [win]
         - if not exist %LIBRARY_INC%\\cudss_distributed_interface.h exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\\cmake\\cudss\\cudss-config.cmake exit 1  # [win]
+        - cmake ${CMAKE_ARGS} -GNinja test  # [build_platform == target_platform]
+        - cmake --build .  # [build_platform == target_platform]
 
   - name: libcudss-examples
     build:
       noarch: generic
     files:
-      - examples/cudss
+      - examples/cudss  # [linux]
+      - Library/examples/cudss  # [win]
     test:
       commands:
         - test -f $PREFIX/examples/cudss/cudss_simple.cpp  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,12 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://developer.download.nvidia.com/compute/cudss/redist/libcudss/{{ platform }}/libcudss-{{ platform }}-{{ version }}_cuda{{ cuda_major }}-archive.{{ extension }}
-    sha256: b52dfec1ee10bf49c706dd36d4808e7fa02f3c8a85f1c2bb7e0da48dcae51cb0  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
-    sha256: 64d77f5a3d2fafc99704da0c0e686d920265708358b9ced5755da713f3ff0620  # [linux64 and (cuda_compiler_version or "").startswith("12")]
-    sha256: d0801e78eab1be1240198e292bc496bb1804f2068975aaaf80ba31c3e400c625  # [win64   and (cuda_compiler_version or "").startswith("12")]
+  - url: https://developer.download.nvidia.com/compute/cudss/redist/libcudss/{{ platform }}/libcudss-{{ platform }}-{{ version }}_cuda{{ cuda_major }}-archive.{{ extension }}  # [aarch64]
+    sha256: b52dfec1ee10bf49c706dd36d4808e7fa02f3c8a85f1c2bb7e0da48dcae51cb0  # [aarch64]
+  - url: https://developer.download.nvidia.com/compute/cudss/redist/libcudss/{{ platform }}/libcudss-{{ platform }}-{{ version }}_cuda{{ cuda_major }}-archive.{{ extension }}  # [linux64]
+    sha256: 64d77f5a3d2fafc99704da0c0e686d920265708358b9ced5755da713f3ff0620  # [linux64]
+  - url: https://developer.download.nvidia.com/compute/cudss/redist/libcudss/{{ platform }}/libcudss-{{ platform }}-{{ version }}_cuda{{ cuda_major }}-archive.{{ extension }}  # [win64]
+    sha256: d0801e78eab1be1240198e292bc496bb1804f2068975aaaf80ba31c3e400c625  # [win64]
   # Overwrite cudss-targets-release.cmake to correct broken paths
   - path: cudss-targets-release.cmake  # [win]
 
@@ -29,11 +31,11 @@ build:
   skip: true  # [(cuda_compiler_version in (None, "None", "11.8")) or (not (linux64 or aarch64 or win64))]
   script:  # [win]
     - md -p %LIBRARY_PREFIX%\examples\cudss  # [win]
-    - xcopy examples %LIBRARY_PREFIX%\examples\cudss /E /I /Y /V # [win]
-    - xcopy include %LIBRARY_INC% /E /I /Y /V # [win]
-    - xcopy lib %LIBRARY_LIB% /E /I /Y /V # [win]
-    - xcopy bin %LIBRARY_BIN% /E /I /Y /V # [win]
-    - xcopy cudss-targets-release.cmake %LIBRARY_LIB%\cmake\cudss\ /I /Y /V # [win]
+    - xcopy examples %LIBRARY_PREFIX%\examples\cudss /E /I /Y /V  # [win]
+    - xcopy include %LIBRARY_INC% /E /I /Y /V  # [win]
+    - xcopy lib %LIBRARY_LIB% /E /I /Y /V  # [win]
+    - xcopy bin %LIBRARY_BIN% /E /I /Y /V  # [win]
+    - xcopy cudss-targets-release.cmake %LIBRARY_LIB%\cmake\cudss\ /I /Y /V  # [win]
 
 requirements:
   build:
@@ -142,6 +144,8 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("libcudss-commlayer-nccl" ~ somajor, exact=True) }}
+    test:
+      commands: []
     about:
       summary: >-
         The NCCL communications layer module for NVIDIA cuDSS
@@ -180,6 +184,8 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("libcudss-commlayer-mpi" ~ somajor, exact=True) }}
+    test:
+      commands: []
     about:
       summary: >-
         The MPI communications layer module for NVIDIA cuDSS


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fixes #1

- File paths on Windows need to be $PREFIX/Library.
- cmake targets contain incorrect paths which needs to be patched for Windows
- address lints from linter

The build number is not bumped because the linux builds are unchanged.